### PR TITLE
fix call_user_func called instead of call_user_func_array

### DIFF
--- a/src/Middleware/RetryModifyRequestMiddleware.php
+++ b/src/Middleware/RetryModifyRequestMiddleware.php
@@ -103,7 +103,7 @@ class RetryModifyRequestMiddleware
     private function onRejected(RequestInterface $req, array $options)
     {
         return function ($reason) use ($req, $options) {
-            if (!call_user_func(
+            if (!call_user_func_array(
                 $this->decider, [
                     $options['retries'],
                     $req,


### PR DESCRIPTION
sould fix #18 : onRejected use call_user_func with an array of args as second argument, so it should be a call_user_func_array as in other calls in the same class.